### PR TITLE
Bump major version of mongoDB db container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   db:
-    image: mongo:3.6
+    image: mongo:4.2.1
     volumes:
       - ${MONGO_VOLUME_MOUNT}:/data/db
     networks:


### PR DESCRIPTION
This bumps the database version a major version and has been tested
and works as it should. WARNING! A backup and restore is recommended
as I had trouble to simply switch out the image and keep the data
volume.