### PR TITLE
Fix internal server error on invalid pattern

### DIFF
--- a/backend/service/service.py
+++ b/backend/service/service.py
@@ -68,12 +68,15 @@ def best_target_match(alias, items):
         match = re.match(item['pattern']+"$", alias, re.I)
         if match:
             # Only substitute matching part of alias
-            target = re.sub(
-                "^" + item['pattern'] + "$",  # make sure entire pattern
-                item['target'],
-                match.group(0),  # only matching part not entire alias
-                flags=re.I  # case insensitive
-            )
+            try:
+                target = re.sub(
+                    "^" + item['pattern'] + "$",  # make sure entire pattern
+                    item['target'],
+                    match.group(0),  # only matching part not entire alias
+                    flags=re.I  # case insensitive
+                )
+            except sre_constants.error:
+                target = item['target']
             return target
 
 


### PR DESCRIPTION
Solves #15

On target with regex insertions i.e. `http://test.com/\1` without
capture group in pattern the resulting answer from the server would be
internal server error. This is fixed with this patch.