### PR TITLE
Only append email domain to user if configured #44

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ LDAP_URI=ldaps://ldap.example.com:636
 LDAP_SEARCH_BASE=dc=example,dc=com
 # where usernames are found
 LDAP_USER_KEY=sAMAccountName
-# <username>@<email domain>
+# if LDAP logins utilize emails user=<username>@<LDAP_EMAIL_DOMAIN>
 LDAP_EMAIL_DOMAIN=example.com
 # where to look for admin privilages
 LDAP_ADMIN_KEY=memberOf

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -113,7 +113,10 @@ class JWTAuth(TokenAuth):
         if not password:
             return jsonify({"msg": "Missing password parameter"}), 400
 
-        user = "{}@{}".format(username, self.app.config["LDAP_EMAIL_DOMAIN"])
+        if len(self.app.config["LDAP_EMAIL_DOMAIN"]) > 0:
+            user = "{}@{}".format(username, self.app.config["LDAP_EMAIL_DOMAIN"])
+        else:
+            user = username
 
         ldap_filter = "(&({user_key}={user})({admin_key}={admin_value}))".format(
             user_key=self.app.config["LDAP_USER_KEY"],


### PR DESCRIPTION
Some LDAP setups might not have logins where the user is configured as
the email address but instead only the username. Such setups will
specify `LDAP_EMAIL_DOMAIN` as blank. That would not work before since
we would still append the `@` symbol on the end.

This change makes sure to only append the `@` symbol of the email domain
is not blank in the configuration.

Should help #44