### PR TITLE
Fix issues with pattern starting with 'api'

### DIFF
--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -52,7 +52,7 @@ http {
         server_name localhost;
 
         # Send api requests to api server
-        location /api {
+        location /api/ {
             include uwsgi_params;
             uwsgi_pass api:5001;
         }

--- a/frontend/nginx/nginx.production.conf
+++ b/frontend/nginx/nginx.production.conf
@@ -164,7 +164,7 @@ http {
         server_name *.company.com;
         expires $expires;
 
-        location /api {
+        location /api/ {
             include uwsgi_params;
             uwsgi_pass api:5001;
         }


### PR DESCRIPTION
Fix a bug with patterns starting with 'api' getting redirected to the
api backend instead of the redirect service.