### PR TITLE
Add additional pattern validation

### DIFF
--- a/frontend/src/containers/AddShortcut.js
+++ b/frontend/src/containers/AddShortcut.js
@@ -44,7 +44,11 @@ class AddShortcut extends Component {
         case "pattern":
           try {
             RegExp(value);
-            if (value.length > 0) {
+            if (
+              value.length > 0 &&
+              value.toLowerCase() !== "api" &&
+              !value.toLowerCase().startsWith("api/")
+            ) {
               this.setState({ patternValid: "valid" });
             } else {
               this.setState({ patternValid: "not-valid" });


### PR DESCRIPTION
Add validation of pattern to make sure that 'api' and patterns starting
with 'api/' is not valid. This is to make sure that users do not insert
patterns which would not work due to being in use by the backend api and
not going towards the redirect service at all.