### PR TITLE
Upgrade deprecated Nodejs version

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
     command: ["flask", "run", "--host=0.0.0.0"] # overrides the uwsgi server
 
   frontend:
-    image: node:13-alpine
+    image: node:14-alpine
     ports:
       - "3000:3000"
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use node image to build static files
-FROM node:13-alpine as builder
+FROM node:14-alpine as builder
 WORKDIR /usr/src/app
 # Install dependencies
 COPY package.json yarn.lock ./


### PR DESCRIPTION
Nodejs 13.x has been deprecated. This upgrades to 14.x which is supported until 2023-04-30.

https://github.com/nodejs/Release

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
