### PR TITLE
Fix issues with special characters in search bar

### DIFF
--- a/frontend/src/containers/SearchBar.js
+++ b/frontend/src/containers/SearchBar.js
@@ -41,10 +41,11 @@ class SearchBar extends Component {
     const { filter } = this.props;
     const { value } = this.state;
     let search = value;
+    search = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special characters
     try {
-      RegExp(value);
+      RegExp(search);
     } catch (error) {
-      search = encodeURI(value);
+      search = encodeURI(search);
     }
     filter(search);
   }


### PR DESCRIPTION
### Describe your changes

If the filter string from the search bar included special characters but still valid regex strings it was not escaped correctly which lead to errors down the line in the front-end code when a json request string was being constructed.

To fix this I simply escape such problematic characters before sending the string down-stream to execute the filtering. This has the benefit of behaving close to how users would expect. A search for \1 results in a request towards mongodb with \\1 which returns strings with \1 in them.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
